### PR TITLE
MEX-707 Implement Subscriptions for TokenPrices

### DIFF
--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -3,4 +3,4 @@ export const FIXED_OUTPUT = 1;
 export const EGLD_IDENTIFIER = 'EGLD';
 export const DIGITS = 4;
 export const MIN_EGLD_DUST = '10000000000000000'; // 0.01 EGLD
-export const POLLING_INTERVAL = 6000; // 6 seconds
+export const POLLING_INTERVAL = 30000; // 30 seconds

--- a/src/hooks/useTokenMetadataSubscription.ts
+++ b/src/hooks/useTokenMetadataSubscription.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { gql, useSubscription } from '@apollo/client';
+
+export interface TokenMetadataChangedType {
+  identifier: string;
+  derivedEGLD: string;
+  liquidityUSD: string;
+  price: string;
+}
+
+const TOKEN_METADATA_SUBSCRIPTION = gql`
+  subscription {
+    tokenMetadataChanged {
+      identifier
+      derivedEGLD
+      liquidityUSD
+      price
+    }
+  }
+`;
+
+export const useTokenMetadataSubscription = () => {
+  const [subscriptionPrices, setSubscriptionPrices] = useState<
+    Record<string, string>
+  >({});
+
+  const { data: subscriptionData } = useSubscription(
+    TOKEN_METADATA_SUBSCRIPTION
+  );
+
+  useEffect(() => {
+    if (subscriptionData?.tokenMetadataChanged) {
+      const { identifier, price } = subscriptionData.tokenMetadataChanged;
+      setSubscriptionPrices((prev) => ({
+        ...prev,
+        [identifier]: price
+      }));
+    }
+  }, [subscriptionData]);
+
+  return {
+    subscriptionPrices,
+    subscriptionData
+  };
+};


### PR DESCRIPTION
- Reduce the polling to 30s from 6s
- Implemented the new subscription endpoint for tokenMetadata ( prices will be pushed to the client when they are updated rather than polled )
- Polling still remains in place as a safeguard at the moment